### PR TITLE
fix a typo

### DIFF
--- a/configs/trainxView2/r50_farseg_changemixin_symmetry.py
+++ b/configs/trainxView2/r50_farseg_changemixin_symmetry.py
@@ -49,7 +49,7 @@ config = dict(
                 symmetry_loss=True,
                 drop_rate=0.2,
                 t1t2=True,
-                t2t2=True
+                t2t1=True
             ),
             loss_config=dict(
                 change=dict(


### PR DESCRIPTION
This is just a typo. But this makes a issue when I tried to train without temporal symmetry.