### PR TITLE
[Feature] support [0~255] gt

### DIFF
--- a/data/levir_cd/dataset.py
+++ b/data/levir_cd/dataset.py
@@ -28,7 +28,7 @@ class LEVIRCD(Dataset):
             blob = self.transforms(**dict(image=imgs, mask=gt))
             imgs = blob['image']
             gt = blob['mask']
-
+        gt[gt>0] = 1
         return imgs, dict(change=gt, image_filename=os.path.basename(self.A_image_fps[idx]))
 
     def __len__(self):


### PR DESCRIPTION
The original dataset of LEVIR-CD consists of 0 and 255. 

However, the segmentation loss of this code works only when it consists of 0 and 1. 

Therefore, I added a code to change gt's 255 to 1.